### PR TITLE
Place scripts in `bin` and not in `share/python`

### DIFF
--- a/bin/brew-pip
+++ b/bin/brew-pip
@@ -39,7 +39,7 @@ def main(args):
                package,
                "--build=%s" % build_dir,
                "--install-option=--prefix=%s" % prefix,
-               "--install-option=--install-scripts=%s" % os.path.join(prefix, "share", "python")]
+               "--install-option=--install-scripts=%s" % os.path.join(prefix, "bin")]
 
         if args.verbose:
             print(" ".join(cmd))


### PR DESCRIPTION
Homebrew now expects scripts installed by `pip` to be placed in `$PREFIX/bin` instead of `$PREFIX/share/python`.